### PR TITLE
Adiciona quebra de linha no arquivo gerado pelo segundo teste

### DIFF
--- a/trabalho1/cliente_servidor/teste_cliente_servidor.sh
+++ b/trabalho1/cliente_servidor/teste_cliente_servidor.sh
@@ -75,7 +75,7 @@ function all-tests {
   ###############################################################################
 
   printf "\n$testNum. TESTA MENSAGEM ALFANUMÉRICA ALEATÓRIA\n"
-  head -c100000 /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' > test_message.txt
+  (head -c100000 /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' ; echo) > test_message.txt
   test "$1" "$2" $3 1 0
   ((testNum++))
 


### PR DESCRIPTION
Segundo a especificação do cliente:

"Cada cliente deve ler e enviar a mensagem exatamente como ela aparece no console/terminal até chegar a um EOF (fim de arquivo)."

Contudo, o segundo teste (TESTA MENSAGEM ALFANUMÉRICA ALEATÓRIA) não adiciona uma quebra de linha (EOF ou \n) no arquivo gerado. Isso impossibilita o teste passar.